### PR TITLE
feat: Add asdf to base image and use it to install Node.js

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: ✨ lint
+name: ✨ Lint
 
 on:
   pull_request:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: 🚀 push
+name: 🚀 Push
 
 on:
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,79 +1,88 @@
 FROM ubuntu:22.04
 
-LABEL maintainer="GBH DevOps Team <devops@gbh.com.do>"
+LABEL maintainer="GBH DevOps Team <devops@gbh.tech>"
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-leo", "pipefail", "-c"]
 
 ARG PHP_VERSION=8.1
+ARG ASDF_VERSION=0.14.0
+ARG NODEJS_VERSION=20
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV NODE_VERSION 20.x
-
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # We accept the risk of installing system dependencies with
 # apt without specifying their versions.
-# hadolint ignore=DL3008
-RUN apt-get update -yq && \
-    apt-get install --no-install-recommends -yq \
-    apt-utils \
-    curl \
-    software-properties-common \
-    ca-certificates \
-    lsb-release \
-    apt-transport-https \
-    gnupg2 \
-    ca-certificates \
-    lsb-release \
-    build-essential \
-    git \
-    locales  \
-    ubuntu-keyring && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    add-apt-repository ppa:ondrej/php && \
-    curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | \
-    tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null && \
-    echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-    http://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" | \
-    tee /etc/apt/sources.list.d/nginx.list && \
-    echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" | \
-    tee /etc/apt/preferences.d/99nginx && \
-    apt-get update -yq && \
-    apt-get install --no-install-recommends -yq \
-    php${PHP_VERSION}-cli \
-    php${PHP_VERSION}-curl \
-    php${PHP_VERSION}-dev \
-    php${PHP_VERSION}-fpm \
-    php${PHP_VERSION}-gd \
-    php${PHP_VERSION}-mbstring \
-    php${PHP_VERSION}-mysql \
-    php${PHP_VERSION}-pgsql \
-    php${PHP_VERSION}-readline \
-    php${PHP_VERSION}-xml \
-    php${PHP_VERSION}-zip \
-    supervisor \
-    unzip \
-    vim \
-    nodejs \
-    nginx && \
-    locale-gen en_US.UTF-8 && \
-    dpkg-reconfigure locales && \
-    mkdir -p /run/php && \
-    update-alternatives --set php /usr/bin/php${PHP_VERSION} && \
-    update-alternatives --set php-config /usr/bin/php-config${PHP_VERSION} && \
-    update-alternatives --set phpize /usr/bin/phpize${PHP_VERSION} && \
-    sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/${PHP_VERSION}/fpm/php.ini && \
-    sed -i "s/display_errors = .*/display_errors = On/" /etc/php/${PHP_VERSION}/fpm/php.ini && \
-    sed -i "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php/${PHP_VERSION}/fpm/php.ini && \
-    sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php/${PHP_VERSION}/fpm/php.ini && \
-    sed -i "s/upload_max_filesize = .*/upload_max_filesize = 100M/" /etc/php/${PHP_VERSION}/fpm/php.ini && \
-    sed -i "s/post_max_size = .*/post_max_size = 100M/" /etc/php/${PHP_VERSION}/fpm/php.ini && \
-    sed -i "s/;date.timezone.*/date.timezone = UTC/" /etc/php/${PHP_VERSION}/fpm/php.ini && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# hadolint ignore=DL3008,SC1091
+RUN apt-get update -yq \
+ && apt-get install --no-install-recommends -yq \
+      apt-utils \
+      curl \
+      software-properties-common \
+      ca-certificates \
+      lsb-release \
+      apt-transport-https \
+      gnupg2 \
+      ca-certificates \
+      lsb-release \
+      build-essential \
+      git \
+      locales  \
+      ubuntu-keyring \
+ && mkdir -p /etc/apt/keyrings \
+ && curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | \
+      tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null \
+ # Install PHP repository
+ && add-apt-repository ppa:ondrej/php \
+ # Install Nginx repository
+ && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+      http://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" | \
+      tee /etc/apt/sources.list.d/nginx.list \
+ && echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" | \
+      tee /etc/apt/preferences.d/99nginx \
+ # Install asdf
+ && git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v${ASDF_VERSION} \
+ && echo ". $HOME/.asdf/asdf.sh" >> ~/.bashrc \
+ && . "$HOME/.asdf/asdf.sh" \
+ # Install Node.js with asdf
+ && asdf plugin add nodejs \
+ && asdf install nodejs latest:${NODEJS_VERSION} \
+ && asdf global nodejs latest:${NODEJS_VERSION} \
+ # Install PHP packages
+ && apt-get update -yq \
+ && apt-get install --no-install-recommends -yq \
+      php${PHP_VERSION}-cli \
+      php${PHP_VERSION}-curl \
+      php${PHP_VERSION}-dev \
+      php${PHP_VERSION}-fpm \
+      php${PHP_VERSION}-gd \
+      php${PHP_VERSION}-mbstring \
+      php${PHP_VERSION}-mysql \
+      php${PHP_VERSION}-pgsql \
+      php${PHP_VERSION}-readline \
+      php${PHP_VERSION}-xml \
+      php${PHP_VERSION}-zip \
+      supervisor \
+      unzip \
+      vim \
+      nginx \
+   && locale-gen en_US.UTF-8 \
+   && dpkg-reconfigure locales \
+   && mkdir -p /run/php \
+   && update-alternatives --set php /usr/bin/php${PHP_VERSION} \
+   && update-alternatives --set php-config /usr/bin/php-config${PHP_VERSION} \
+   && update-alternatives --set phpize /usr/bin/phpize${PHP_VERSION} \
+   # Update php.ini for FPM
+   && sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/${PHP_VERSION}/fpm/php.ini \
+   && sed -i "s/display_errors = .*/display_errors = On/" /etc/php/${PHP_VERSION}/fpm/php.ini \
+   && sed -i "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php/${PHP_VERSION}/fpm/php.ini \
+   && sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php/${PHP_VERSION}/fpm/php.ini \
+   && sed -i "s/upload_max_filesize = .*/upload_max_filesize = 100M/" /etc/php/${PHP_VERSION}/fpm/php.ini \
+   && sed -i "s/post_max_size = .*/post_max_size = 100M/" /etc/php/${PHP_VERSION}/fpm/php.ini \
+   && sed -i "s/;date.timezone.*/date.timezone = UTC/" /etc/php/${PHP_VERSION}/fpm/php.ini \
+   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # hadolint ignore=DL3022
 COPY --from=composer:2.6.5 /usr/bin/composer /usr/bin/composer
@@ -81,13 +90,14 @@ COPY --from=composer:2.6.5 /usr/bin/composer /usr/bin/composer
 COPY nginx/site.conf /etc/nginx/conf.d/site.conf
 COPY supervisor /etc/supervisor/conf.d
 
-# PHP_VERSION is an ARG, even if 7.4 is the default we want
+# PHP_VERSION is an ARG, even if 8.0 is the default we want
 # to make sure we use the specified version here.
-RUN sed -i "s/7.4/${PHP_VERSION}/" /etc/nginx/conf.d/site.conf \
-&&  sed -i "s/7.4/${PHP_VERSION}/g" /etc/supervisor/conf.d/php-fpm.conf
+RUN sed -i "s/8.0/${PHP_VERSION}/" /etc/nginx/conf.d/site.conf \
+ && sed -i "s/8.0/${PHP_VERSION}/g" /etc/supervisor/conf.d/php-fpm.conf
 
 # Fix www-data user in nginx.conf file
 RUN sed -i "s/user\s*nginx;/user www-data;/g" /etc/nginx/nginx.conf
+
 WORKDIR /usr/app
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
 <!-- omit in toc -->
-# Docker images - LEP
+# gbh.tech - Linux, Nginx PHP (LEP) Docker Image
 
-- [:page\_facing\_up: Description](#page_facing_up-description)
-- [:card\_file\_box: Included dependencies](#card_file_box-included-dependencies)
-- [:bookmark\_tabs: Relevant considerations](#bookmark_tabs-relevant-considerations)
-- [:dart: How To Use](#dart-how-to-use)
-- [:whale2: Build your image](#whale2-build-your-image)
-- [:rocket: Run your app](#rocket-run-your-app)
+[![🧪 Tests](https://github.com/gbh-tech/lep-docker/actions/workflows/test.yml/badge.svg)](https://github.com/gbh-tech/lep-docker/actions/workflows/test.yml)
+[![🚀 Push](https://github.com/gbh-tech/lep-docker/actions/workflows/push.yml/badge.svg)](https://github.com/gbh-tech/lep-docker/actions/workflows/push.yml)
+[![✨ Lint](https://github.com/gbh-tech/lep-docker/actions/workflows/lint.yml/badge.svg)](https://github.com/gbh-tech/lep-docker/actions/workflows/lint.yml)
 
-## :page_facing_up: Description
+<!-- omit in toc -->
+## Content
 
-LEP comes from the original `LAMP` stack which was based on **L**inux, **A**pache, **M**ySQL and **P**HP. LEP is a docker-oriented alternative that uses Nginx in favor Apache and separates the MySQL dependency since it can be configured as a service using docker compose.
+- [📄 Description](#-description)
+- [🗃️ Included dependencies](#️-included-dependencies)
+- [🔖 Relevant considerations](#-relevant-considerations)
+- [🎯 How To Use](#-how-to-use)
+- [🐳 Build your image](#-build-your-image)
+- [🚀 Run your app](#-run-your-app)
 
-> **Note**: This image is **not meant for production** use. It was designed to serve as an auxiliary image for development and testing environments.
+## 📄 Description
 
-## :card_file_box: Included dependencies
+LEP comes from the original `LAMP` stack which was based on **L**inux,
+**A**pache, **M**ySQL and **P**HP. LEP is a docker-oriented alternative
+that uses Nginx in favor Apache and separates the MySQL dependency since it
+can be configured as a service using docker compose.
+
+> **Note**: This image is **not meant for production** use. It was designed
+> to serve as an auxiliary image for development and testing environments.
+
+## 🗃️ Included dependencies
 
 - Ubuntu Jammy
 - Node.js 20.x
-- git
-- nginx
+- Git
+- Nginx
 - PHP (7.4, 8.0, 8.1)
   - php-cli
   - php-curl
@@ -34,13 +45,16 @@ LEP comes from the original `LAMP` stack which was based on **L**inux, **A**pach
   - php-xml
   - php-zip
 
-## :bookmark_tabs: Relevant considerations
+## 🔖 Relevant considerations
 
-- The default user for your web files should be `www-data`. If the permissions of your files are not properly set, you might end up with HTTP 403 errors from the web server.
+- The default user for your web files should be `www-data`.
+  If the permissions of your files are not properly set, you might end up
+  with HTTP 403 errors from the web server.
 
-## :dart: How To Use
+## 🎯 How To Use
 
-To use this image, you should set it as your base image using the `FROM` instruction:
+To use this image, you should set it as your base image using the
+`FROM` instruction:
 
 ```docker
 FROM solucionesgbh/lep:${PHP_VERSION}
@@ -65,7 +79,7 @@ COPY --chown=www-data:www-data .
 CMD ["/usr/bin/supervisord", "--nodaemon", "-c", "/etc/supervisor/supervisord.conf"]
 ```
 
-## :whale2: Build your image
+## 🐳 Build your image
 
 To build your custom image, on your terminal execute the following `docker build` command:
 
@@ -73,7 +87,7 @@ To build your custom image, on your terminal execute the following `docker build
 docker build . -t myapp:myversion
 ```
 
-## :rocket: Run your app
+## 🚀 Run your app
 
 To run your custom container, on your terminal execute the following `docker run` command:
 

--- a/nginx/site.conf
+++ b/nginx/site.conf
@@ -1,5 +1,5 @@
 upstream php {
-  server unix:/run/php/php7.4-fpm.sock;
+  server unix:/run/php/php8.0-fpm.sock;
 }
 
 server {

--- a/supervisor/php-fpm.conf
+++ b/supervisor/php-fpm.conf
@@ -1,5 +1,5 @@
 [program:php-fpm]
-command=/usr/sbin/php-fpm7.4 --nodaemonize --fpm-config=/etc/php/7.4/fpm/php-fpm.conf
+command=/usr/sbin/php-fpm8.0 --nodaemonize --fpm-config=/etc/php/8.0/fpm/php-fpm.conf
 autostart=true
 autorestart=true
 priority=5


### PR DESCRIPTION
## Summary
- Minor aesthetic features.
- Install asdf to manage dependencies easily in downstream images.
- Use asdf to install Node.js.
- Add badges to README.md.